### PR TITLE
use netstandard2.0

### DIFF
--- a/PingPayments.PaymentsApi/Payments/Shared/V1/MethodEnumHelpers.cs
+++ b/PingPayments.PaymentsApi/Payments/Shared/V1/MethodEnumHelpers.cs
@@ -17,7 +17,7 @@ namespace PingPayments.PaymentsApi.Payments.Shared.V1
             {
                 "e_commerce" => MethodEnum.e_commerce,
                 "m_commerce" => MethodEnum.m_commerce,
-                _ => Enum.Parse<MethodEnum>(methodEnumValue)
+                _ => (MethodEnum)Enum.Parse(typeof(MethodEnum), methodEnumValue)
             };
     }
 }

--- a/PingPayments.PaymentsApi/PingPayments.PaymentsApi.csproj
+++ b/PingPayments.PaymentsApi/PingPayments.PaymentsApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/PingPayments.PaymentsApi/PingPaymentsApiClient.cs
+++ b/PingPayments.PaymentsApi/PingPaymentsApiClient.cs
@@ -52,7 +52,7 @@ namespace PingPayments.PaymentsApi
             );
             _merchants = new Lazy<IMerchantResource>(() => new MerchantResource(merchantV1));
 
-            _ping = new Lazy<IPingResource>(() => new PingResource(new PingV1(new Lazy<PingOperation>(new PingOperation(httpClient)))));
+            _ping = new Lazy<IPingResource>(() => new PingResource(new PingV1(new Lazy<PingOperation>(() => new PingOperation(httpClient)))));
         }
 
         private readonly Lazy<IPaymentResource> _payments;


### PR DESCRIPTION
Använder netstandard2.0 istället för 2.1 för att stödja entity-framework.
