### PR TITLE
New http setup design for better DX

### DIFF
--- a/PingPayment.PaymentLinksApi/PingPaymentLinksApiClient.cs
+++ b/PingPayment.PaymentLinksApi/PingPaymentLinksApiClient.cs
@@ -1,24 +1,26 @@
-﻿using PingPayments.PaymentLinksApi.Ping;
-using PingPayments.PaymentLinksApi.Ping.V1;
-using PingPayments.PaymentLinksApi.PaymentLinks;
-using PingPayments.PaymentLinksApi.PaymentLinks.List.V1;
-using PingPayments.PaymentLinksApi.PaymentLinks.Get.V1;
-using PingPayments.PaymentLinksApi.PaymentLinks.Create.V1;
-using PingPayments.PaymentLinksApi.PaymentLinks.Cancel.V1;
-using PingPayments.PaymentLinksApi.PaymentLinks.Send.V1;
-using PingPayments.PaymentLinksApi.Files.Invoice;
+﻿using PingPayments.PaymentLinksApi.Files.Invoice;
 using PingPayments.PaymentLinksApi.Files.Invoice.Create.V1;
 using PingPayments.PaymentLinksApi.Files.Invoice.Get.V1;
 using PingPayments.PaymentLinksApi.Files.Receipt;
 using PingPayments.PaymentLinksApi.Files.Receipt.Get.V1;
-
+using PingPayments.PaymentLinksApi.PaymentLinks;
+using PingPayments.PaymentLinksApi.PaymentLinks.Cancel.V1;
+using PingPayments.PaymentLinksApi.PaymentLinks.Create.V1;
+using PingPayments.PaymentLinksApi.PaymentLinks.Get.V1;
+using PingPayments.PaymentLinksApi.PaymentLinks.List.V1;
+using PingPayments.PaymentLinksApi.PaymentLinks.Send.V1;
+using PingPayments.PaymentLinksApi.Ping;
+using PingPayments.PaymentLinksApi.Ping.V1;
+using PingPayments.Shared;
 
 namespace PingPayments.PaymentLinksApi
 {
     public class PingPaymentLinksApiClient : IPingPaymentLinksApiClient
     {
-        public PingPaymentLinksApiClient(HttpClient httpClient)
+        public PingPaymentLinksApiClient(string uri, Guid tenantId)
         {
+            HttpClient httpClient = new HttpClient().ConfigurePingPaymentsClient(uri, tenantId);
+
             var pingV1 = new PingV1
             (
                 new Lazy<PingOperation>(() => new PingOperation(httpClient))
@@ -30,9 +32,9 @@ namespace PingPayments.PaymentLinksApi
             (
                 new Lazy<ListPaymentLinksOperation>(() => new ListPaymentLinksOperation(httpClient)),
                 new Lazy<CreatePaymentLinkOperation>(() => new CreatePaymentLinkOperation(httpClient)),
-                new Lazy<GetPaymentLinkOperation>(()=> new GetPaymentLinkOperation(httpClient)),
-                new Lazy<CancelPaymentLinkOperation>(()=> new CancelPaymentLinkOperation(httpClient)),
-                new Lazy<SendPaymentLinkOperation>(()=> new SendPaymentLinkOperation(httpClient))
+                new Lazy<GetPaymentLinkOperation>(() => new GetPaymentLinkOperation(httpClient)),
+                new Lazy<CancelPaymentLinkOperation>(() => new CancelPaymentLinkOperation(httpClient)),
+                new Lazy<SendPaymentLinkOperation>(() => new SendPaymentLinkOperation(httpClient))
             );
             _paymentLinks = new Lazy<IPaymentLinksResource>(() => new PaymentLinkResource(paymentLinksV1));
 

--- a/PingPayments.PaymentLinksApi.Tests/V1/BaseResourceTests.cs
+++ b/PingPayments.PaymentLinksApi.Tests/V1/BaseResourceTests.cs
@@ -1,17 +1,15 @@
-﻿using PingPayments.Shared;
-using PingPayments.PaymentLinksApi.Helpers;
+﻿using PingPayments.PaymentLinksApi.Helpers;
+using PingPayments.Shared;
 
 namespace PingPayments.PaymentLinksApi.Tests.V1
 {
     public class BaseResourceTests
     {
         protected readonly IPingPaymentLinksApiClient _api;
-        private readonly HttpClient _httpClient;
 
         public BaseResourceTests()
         {
-            _httpClient = new HttpClient().ConfigurePingPaymentsClient(PingEnvironments.SandboxUri, TestData.TenantId);
-            _api = new PingPaymentLinksApiClient(_httpClient);
+            _api = new PingPaymentLinksApiClient(PingEnvironments.SandboxUri, TestData.TenantId);
         }
 
         protected static void AssertHttpOK<T>(ApiResponseBase<T> response) where T : EmptySuccesfulResponseBody

--- a/PingPayments.PaymentsApi.Tests/V1/BaseResourceTests.cs
+++ b/PingPayments.PaymentsApi.Tests/V1/BaseResourceTests.cs
@@ -1,6 +1,5 @@
-﻿using PingPayments.Shared;
-using PingPayments.PaymentsApi.Helpers;
-using System.Net.Http;
+﻿using PingPayments.PaymentsApi.Helpers;
+using PingPayments.Shared;
 using Xunit;
 
 namespace PingPayments.PaymentsApi.Tests.V1
@@ -8,12 +7,10 @@ namespace PingPayments.PaymentsApi.Tests.V1
     public class BaseResourceTests
     {
         protected readonly IPingPaymentsApiClient _api;
-        private readonly HttpClient _httpClient;
 
         public BaseResourceTests()
         {
-            _httpClient = new HttpClient().ConfigurePingPaymentsClient(PingEnvironments.SandboxUri, TestData.TenantId);
-            _api = new PingPaymentsApiClient(_httpClient);
+            _api = new PingPaymentsApiClient(PingEnvironments.SandboxUri, TestData.TenantId);
         }
 
         protected static void AssertHttpOK<T>(ApiResponseBase<T> response) where T : EmptySuccesfulResponseBody

--- a/PingPayments.PaymentsApi/PingPaymentsApiClient.cs
+++ b/PingPayments.PaymentsApi/PingPaymentsApiClient.cs
@@ -15,6 +15,7 @@ using PingPayments.PaymentsApi.Payments.Get.V1;
 using PingPayments.PaymentsApi.Payments.Initiate.V1;
 using PingPayments.PaymentsApi.Ping;
 using PingPayments.PaymentsApi.Ping.V1;
+using PingPayments.Shared;
 using System;
 using System.Net.Http;
 
@@ -25,8 +26,10 @@ namespace PingPayments.PaymentsApi
     /// </summary>
     public class PingPaymentsApiClient : IPingPaymentsApiClient
     {
-        public PingPaymentsApiClient(HttpClient httpClient)
+        public PingPaymentsApiClient(string uri, Guid tenantId)
         {
+            HttpClient httpClient = new HttpClient().ConfigurePingPaymentsClient(uri, tenantId);
+
             var paymentsV1 = new PaymentsV1
             (
                 new Lazy<InitiateOperation>(() => new InitiateOperation(httpClient)),


### PR DESCRIPTION
Gjorde om designen lite så att det blir lättare och mer intuitivt när man skapar en client.  

Med den nya designen skapar man en client på följande sätt: 
`api =  new PingPaymentsApiClient(PingEnvironments.SandboxUri, TestData.TenantId);`

Med den gamla designen behövde man göra följande:
` httpClient = new HttpClient().ConfigurePingPaymentsClient(PingEnvironments.SandboxUri, TestData.TenantId);`
`  api = new PingPaymentsApiClient(httpClient);`