### PR TITLE
added split parameters to update

### DIFF
--- a/PingPayment.PaymentLinksApi/PaymentLinks/Send/V1/SendPaymentLinkOperation.cs
+++ b/PingPayment.PaymentLinksApi/PaymentLinks/Send/V1/SendPaymentLinkOperation.cs
@@ -1,8 +1,8 @@
 ﻿using PingPayments.PaymentLinksApi.PaymentLinks.Send.V1.Requests;
-using PingPayments.Shared.Helpers;
 using PingPayments.Shared;
-using System.Text.Json.Serialization;
+using PingPayments.Shared.Helpers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using static PingPayments.Shared.Enums.HttpRequestTypeEnum;
 using static System.Net.HttpStatusCode;
 
@@ -16,14 +16,14 @@ namespace PingPayments.PaymentLinksApi.PaymentLinks.Send.V1
             await BaseExecute
             (
                 PUT,
-                $"api/v1/payment_links/{request.paymentLinkID}/distribute", 
+                $"api/v1/payment_links/{request.paymentLinkID}/distribute",
                 request,
                 await ToJson(request.sendPaymentLinkRequestBody)
             );
 
         protected override JsonSerializerOptions JsonSerializerOptions => new()
         {
-            Converters = {  new JsonStringEnumConverter()   },
+            Converters = { new JsonStringEnumConverter() },
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 

--- a/PingPayments.PaymentsApi.Tests/TestSetup.json
+++ b/PingPayments.PaymentsApi.Tests/TestSetup.json
@@ -1,8 +1,8 @@
 {
-  "TENANTID": "",
-  "MERCHANTID": "",
-  "ORDERID": "",
-  "SPLITTREEID": "",
-  "PAYMENTID": "",
-  "PAYOUTID": ""
+  "TENANTID": "a2a4f648-a50b-42fb-bda8-00c6e2f295ea",
+  "MERCHANTID": "70166bfa-2b5f-42f8-abe1-a614e32ad1b2",
+  "ORDERID": "2c771525-a198-4aeb-9e93-4a4222f03443",
+  "SPLITTREEID": "4f3a07d4-ef83-4040-bcc4-0a6e6bfab6ab",
+  "PAYMENTID": "82dddcd6-89a6-435f-93a2-a62016c2a771",
+  "PAYOUTID": "b7e5db44-6b88-4e43-b24c-6a314e1a44a9"
 }

--- a/PingPayments.PaymentsApi.Tests/V1/PaymentOrderResourceTests.cs
+++ b/PingPayments.PaymentsApi.Tests/V1/PaymentOrderResourceTests.cs
@@ -1,6 +1,7 @@
 using PingPayments.PaymentsApi.Helpers;
 using PingPayments.PaymentsApi.PaymentOrders.Create.V1;
 using PingPayments.PaymentsApi.PaymentOrders.Shared.V1;
+using PingPayments.PaymentsApi.PaymentOrders.Update.V1;
 using PingPayments.PaymentsApi.Payments.Get.V1;
 using PingPayments.PaymentsApi.Payments.Shared.V1;
 using PingPayments.PaymentsApi.Payments.V1.Initiate.Request;
@@ -68,13 +69,20 @@ namespace PingPayments.PaymentsApi.Tests.V1
         }
 
         [Fact]
-        public async Task Can_update_order_with_split_tree_id()
+        public async Task Can_update_order_with_split_tree_id_and_split_parameters()
         {
+            dynamic splitParamters = new { tenant_fee = 20.ToMinorCurrencyUnit() };
+            var updateRequest = new UpdatePaymentOrderRequest
+            (
+                SplitParamters: splitParamters,
+                SplitTreeId: TestData.SplitTreeId
+            );
+
             var response = await _api.PaymentOrder.V1.Update
-            ((
+            (
                 TestData.OrderId,
-                TestData.SplitTreeId
-            ));
+                updateRequest
+            );
             AssertHttpNoContent(response);
         }
 

--- a/PingPayments.PaymentsApi/PaymentOrders/IPaymentOrderV1.cs
+++ b/PingPayments.PaymentsApi/PaymentOrders/IPaymentOrderV1.cs
@@ -1,6 +1,7 @@
 ﻿using PingPayments.PaymentsApi.PaymentOrders.Create.V1;
 using PingPayments.PaymentsApi.PaymentOrders.Get.V1;
 using PingPayments.PaymentsApi.PaymentOrders.List.V1;
+using PingPayments.PaymentsApi.PaymentOrders.Update.V1;
 using PingPayments.Shared;
 using System;
 using System.Threading.Tasks;
@@ -12,7 +13,7 @@ namespace PingPayments.PaymentsApi.PaymentOrders
         Task<GuidResponse> Create(CreatePaymentOrderRequest createPaymentOrderRequest);
         Task<PaymentOrderResponse> Get(Guid orderId);
         Task<PaymentOrdersResponse> List((DateTimeOffset from, DateTimeOffset to)? dateFilter = null);
-        Task<EmptyResponse> Update((Guid OrderId, Guid SplitTreeId) updateRequest);
+        Task<EmptyResponse> Update(Guid OrderId, UpdatePaymentOrderRequest updatePaymentOrderRequest);
         Task<EmptyResponse> Close(Guid orderId);
         Task<EmptyResponse> Split(Guid orderId, bool fastForward = false);
         Task<EmptyResponse> Settle(Guid orderId, bool fastForward = false);

--- a/PingPayments.PaymentsApi/PaymentOrders/PaymentOrderV1.cs
+++ b/PingPayments.PaymentsApi/PaymentOrders/PaymentOrderV1.cs
@@ -44,8 +44,8 @@ namespace PingPayments.PaymentsApi.PaymentOrders
             await _listPaymentOrderOperation.Value.ExecuteRequest(dateFilter);
         public async Task<GuidResponse> Create(CreatePaymentOrderRequest createPaymentOrderRequest) =>
             await _createPaymentOrderOperation.Value.ExecuteRequest(createPaymentOrderRequest);
-        public async Task<EmptyResponse> Update((Guid OrderId, Guid SplitTreeId) updateRequest) =>
-            await _updatePaymentOrderOperation.Value.ExecuteRequest(updateRequest);
+        public async Task<EmptyResponse> Update(Guid orderId, UpdatePaymentOrderRequest updatePaymentOrderRequest) =>
+            await _updatePaymentOrderOperation.Value.ExecuteRequest((orderId, updatePaymentOrderRequest));
         public async Task<EmptyResponse> Close(Guid orderId) =>
             await _closePaymentOrderOperation.Value.ExecuteRequest(orderId);
         public async Task<EmptyResponse> Split(Guid orderId, bool fastForward = false) =>

--- a/PingPayments.PaymentsApi/PaymentOrders/Update/V1/UpdatePaymentOrderOperation.cs
+++ b/PingPayments.PaymentsApi/PaymentOrders/Update/V1/UpdatePaymentOrderOperation.cs
@@ -1,26 +1,32 @@
 ﻿using PingPayments.Shared;
 using System;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using static PingPayments.Shared.Enums.HttpRequestTypeEnum;
 using static System.Net.HttpStatusCode;
 
 namespace PingPayments.PaymentsApi.PaymentOrders.Update.V1
 {
-    public class UpdatePaymentOrderOperation : OperationBase<(Guid OrderId, Guid SplitTreeId), EmptyResponse>
+    public class UpdatePaymentOrderOperation : OperationBase<(Guid OrderId, UpdatePaymentOrderRequest updatePaymentOrderRequest), EmptyResponse>
     {
         public UpdatePaymentOrderOperation(HttpClient httpClient) : base(httpClient) { }
 
-        public override async Task<EmptyResponse> ExecuteRequest((Guid OrderId, Guid SplitTreeId) updateRequest) => 
+        public override async Task<EmptyResponse> ExecuteRequest((Guid OrderId, UpdatePaymentOrderRequest updatePaymentOrderRequest) request) =>
             await BaseExecute
             (
                 PUT,
-                $"api/v1/payment_orders/{updateRequest.OrderId}",
-                updateRequest,
-                await ToJson(new { split_tree_id = updateRequest.SplitTreeId })
+                $"api/v1/payment_orders/{request.OrderId}",
+                request,
+                await ToJson(request.updatePaymentOrderRequest)
             );
+        protected override JsonSerializerOptions JsonSerializerOptions => new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
 
-        protected override async Task<EmptyResponse> ParseHttpResponse(HttpResponseMessage hrm, (Guid OrderId, Guid SplitTreeId) _) => 
+        protected override async Task<EmptyResponse> ParseHttpResponse(HttpResponseMessage hrm, (Guid OrderId, UpdatePaymentOrderRequest updatePaymentOrderRequest) _) =>
             hrm.StatusCode switch
             {
                 NoContent => EmptyResponse.Succesful(hrm.StatusCode),

--- a/PingPayments.PaymentsApi/PaymentOrders/Update/V1/UpdatePaymentOrderRequest.cs
+++ b/PingPayments.PaymentsApi/PaymentOrders/Update/V1/UpdatePaymentOrderRequest.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PingPayments.PaymentsApi.PaymentOrders.Update.V1
+{
+
+    public record UpdatePaymentOrderRequest(dynamic? SplitParamters = null, Guid? SplitTreeId = null)
+    {
+        /// <summary>
+        /// Parameters used to control parts of the split tree
+        /// </summary>
+        [JsonPropertyName("split_parameters")]
+        public dynamic? SplitParamters { get; set; } = SplitParamters ?? new Dictionary<string, dynamic>();
+
+        /// <summary>
+        /// Split tree used for the payment order
+        /// </summary>
+        [JsonPropertyName("split_tree_id")]
+        public Guid? SplitTreeId { get; set; } = SplitTreeId;
+    }
+}


### PR DESCRIPTION
Jag gjorde en updatePaymentOrderRequest som innehåller splitParameters och splitTreeId. Är detta bättre än att bara ha dessa som parametrar? (2 parametrar istället för 3)