### PR TITLE
Ais kyc merchant added

### DIFF
--- a/PingPayment.PaymentLinksApi/PingPayments.PaymentLinksApi.csproj
+++ b/PingPayment.PaymentLinksApi/PingPayments.PaymentLinksApi.csproj
@@ -7,7 +7,7 @@
 	  <LangVersion>10</LangVersion>
 	  <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	  <PackageId>PingPayments.PaymentLinks</PackageId>
-	  <Version>0.2.3-alpha</Version>
+	  <Version>1.0.0</Version>
 	  <Authors>pingpaymentsab</Authors>
 	  <Company>Ping Payments AB</Company>
 	  <Owners>Ping Payments</Owners>

--- a/PingPayments.KYC.Tests/V1/MerchantTest.cs
+++ b/PingPayments.KYC.Tests/V1/MerchantTest.cs
@@ -1,4 +1,5 @@
-﻿using PingPayments.KYC.Merchant.V1.Get;
+﻿using PingPayments.KYC.Merchant.V1.AIS;
+using PingPayments.KYC.Merchant.V1.Get;
 using PingPayments.KYC.Merchant.V1.Verification;
 using PingPayments.KYC.Shared;
 using PingPayments.Tests;
@@ -104,6 +105,43 @@ namespace PingPayments.KYC.Tests.V1
 
             var response = await _api.Merchant.V1.Verification(request);
             AssertBadRequest(response);
+        }
+
+        [Fact]
+        public async Task Ais_merchant_with_full_body_exept_redirects_return_200()
+        {
+            Styles stylesObj = new()
+            {
+                BackgroundColor = "#47e331",
+                FormBackgroundColor = "#44aacc",
+                Primary = "#ffe7ec"
+            };
+
+            Distribution distributionObj = new()
+            {
+                EmailOptions = new EmailOptions() { Distribute = true, Originator = "originator" },
+                SmsOptions = new SmsOptions() { Distribute = true, Message = "a message", Originator = "originator" }
+            };
+            var request = new AisMerchantRequest
+            (
+                tenantId: TestData.TenantId,
+                merchantId: TestData.MerchantId,
+                country: "SE",
+                distribution: distributionObj,
+                email: "test.mail@gmail.com",
+                phoneNumber: "0701231212",
+                psuId: "199412345676",
+                styles: stylesObj
+            );
+
+            var response = await _api.Merchant.V1.AIS(request);
+            AssertHttpOK(response);
+        }
+
+        [Fact]
+        public async Task Ais_merchant_with_bad_request_return_400()
+        {
+            AssertBadRequest(await _api.Merchant.V1.AIS(null));
         }
     }
 }

--- a/PingPayments.KYC/Merchant/IMerchantV1.cs
+++ b/PingPayments.KYC/Merchant/IMerchantV1.cs
@@ -1,4 +1,6 @@
-﻿using PingPayments.KYC.Merchant.V1.Get;
+﻿using PingPayments.KYC.Merchant.V1.AIS;
+using PingPayments.KYC.Merchant.V1.AIS.Response;
+using PingPayments.KYC.Merchant.V1.Get;
 using PingPayments.KYC.Merchant.V1.Get.Response;
 using PingPayments.KYC.Merchant.V1.Verification;
 using PingPayments.Shared;
@@ -9,6 +11,7 @@ namespace PingPayments.KYC.Merchant
     public interface IMerchantV1
     {
         Task<GetKycResponse> Get(GetKycRequest request);
+        Task<AisMerchantResponse> AIS(AisMerchantRequest request);
         Task<EmptyResponse> Verification(KycVerificationRequest request);
     }
 }

--- a/PingPayments.KYC/Merchant/MerchantV1.cs
+++ b/PingPayments.KYC/Merchant/MerchantV1.cs
@@ -1,4 +1,6 @@
-﻿using PingPayments.KYC.Merchant.V1.Get;
+﻿using PingPayments.KYC.Merchant.V1.AIS;
+using PingPayments.KYC.Merchant.V1.AIS.Response;
+using PingPayments.KYC.Merchant.V1.Get;
 using PingPayments.KYC.Merchant.V1.Get.Response;
 using PingPayments.KYC.Merchant.V1.Verification;
 using PingPayments.Shared;
@@ -9,19 +11,27 @@ namespace PingPayments.KYC.Merchant
 {
     public class MerchantV1 : IMerchantV1
     {
-        public MerchantV1(Lazy<KycVerificationOperation> merchantVerificationOperation, Lazy<GetKycOperation> getMerchantKycOperation)
+        public MerchantV1(
+            Lazy<KycVerificationOperation> merchantVerificationOperation,
+            Lazy<GetKycOperation> getMerchantKycOperation,
+            Lazy<AisKycMerchantOperation> aisKycMerchantOperation)
         {
             _merchantVerificationOperation = merchantVerificationOperation;
             _getMerchantKycOperation = getMerchantKycOperation;
+            _aisKycMerchantOperation = aisKycMerchantOperation;
         }
 
         private readonly Lazy<KycVerificationOperation> _merchantVerificationOperation;
         private readonly Lazy<GetKycOperation> _getMerchantKycOperation;
+        private readonly Lazy<AisKycMerchantOperation> _aisKycMerchantOperation;
 
         public async Task<EmptyResponse> Verification(KycVerificationRequest merchantVerificationRequest) =>
             await _merchantVerificationOperation.Value.ExecuteRequest(merchantVerificationRequest);
 
         public async Task<GetKycResponse> Get(GetKycRequest request) =>
             await _getMerchantKycOperation.Value.ExecuteRequest(request);
+
+        public async Task<AisMerchantResponse> AIS(AisMerchantRequest request) =>
+            await _aisKycMerchantOperation.Value.ExecuteRequest(request);
     }
 }

--- a/PingPayments.KYC/Merchant/V1/AIS/AisKycMerchantOperation.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/AisKycMerchantOperation.cs
@@ -1,0 +1,43 @@
+﻿using PingPayments.KYC.Merchant.V1.AIS.Response;
+using PingPayments.Shared;
+using PingPayments.Shared.Helpers;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using static PingPayments.Shared.Enums.HttpRequestTypeEnum;
+using static System.Net.HttpStatusCode;
+
+namespace PingPayments.KYC.Merchant.V1.AIS
+{
+    public class AisKycMerchantOperation : OperationBase<AisMerchantRequest, AisMerchantResponse>
+    {
+        public AisKycMerchantOperation(HttpClient httpClient) : base(httpClient) { }
+
+        protected override JsonSerializerOptions JsonSerializerOptions => new()
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        };
+
+        public override async Task<AisMerchantResponse> ExecuteRequest(AisMerchantRequest request) =>
+            await BaseExecute
+            (
+                POST,
+                "api/merchant_ais",
+                request,
+                await ToJson(request)
+            );
+
+        protected override async Task<AisMerchantResponse> ParseHttpResponse(HttpResponseMessage hrm, AisMerchantRequest _)
+        {
+            var responseBody = await hrm.Content.ReadAsStringAsyncMemoized();
+            var response = hrm.StatusCode switch
+            {
+                OK => AisMerchantResponse.Successful(hrm.StatusCode, await Deserialize<AisMerchantResponseBody>(responseBody), responseBody),
+                _ => AisMerchantResponse.Failure(hrm.StatusCode, await Deserialize<ErrorResponseBody>(responseBody), responseBody)
+            };
+            return response;
+        }
+    }
+}
+

--- a/PingPayments.KYC/Merchant/V1/AIS/AisMerchantRequest.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/AisMerchantRequest.cs
@@ -49,7 +49,7 @@ namespace PingPayments.KYC.Merchant.V1.AIS
         public string Country { get; set; }
 
         /// <summary>
-        /// Number of elements per page
+        /// Way of distribution
         /// </summary>
         [JsonPropertyName("distribution")]
         public Distribution? Distribution { get; set; }
@@ -79,7 +79,7 @@ namespace PingPayments.KYC.Merchant.V1.AIS
         public Redirects? Redirects { get; set; }
 
         /// <summary>
-        /// Merchants phone number
+        /// Style options
         /// </summary>
         [JsonPropertyName("styles")]
         public Styles? Styles { get; set; }

--- a/PingPayments.KYC/Merchant/V1/AIS/AisMerchantRequest.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/AisMerchantRequest.cs
@@ -1,0 +1,88 @@
+﻿using PingPayments.KYC.Shared;
+using System;
+using System.Text.Json.Serialization;
+
+namespace PingPayments.KYC.Merchant.V1.AIS
+{
+    public record AisMerchantRequest
+    {
+        public AisMerchantRequest
+        (
+            Guid tenantId,
+            Guid merchantId,
+            string country,
+            Distribution? distribution = null,
+            string? email = null,
+            string? phoneNumber = null,
+            string? psuId = null,
+            Redirects? redirects = null,
+            Styles? styles = null
+
+        )
+        {
+            TenantId = tenantId;
+            MerchantId = merchantId;
+            Country = country;
+            Distribution = distribution;
+            Email = email;
+            PhoneNumber = phoneNumber;
+            PsuId = psuId;
+            Redirects = redirects;
+            Styles = styles;
+        }
+        /// <summary>
+        /// Number of elements per page
+        /// </summary>
+        [JsonPropertyName("tenant_id")]
+        public Guid TenantId { get; set; }
+
+        /// <summary>
+        /// Get by Merchant ID
+        /// </summary>
+        [JsonPropertyName("merchant_id")]
+        public Guid MerchantId { get; set; }
+
+        /// <summary>
+        /// Country of merchant
+        /// </summary>
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+
+        /// <summary>
+        /// Number of elements per page
+        /// </summary>
+        [JsonPropertyName("distribution")]
+        public Distribution? Distribution { get; set; }
+
+        /// <summary>
+        /// Merchant email
+        /// </summary>
+        [JsonPropertyName("email")]
+        public string? Email { get; set; }
+
+        /// <summary>
+        /// Merchants phone number
+        /// </summary>
+        [JsonPropertyName("phone")]
+        public string? PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Merchants psu id
+        /// </summary>
+        [JsonPropertyName("psu_id")]
+        public string? PsuId { get; set; }
+
+        /// <summary>
+        /// Object of redirect urls
+        /// </summary>
+        [JsonPropertyName("redirects")]
+        public Redirects? Redirects { get; set; }
+
+        /// <summary>
+        /// Merchants phone number
+        /// </summary>
+        [JsonPropertyName("styles")]
+        public Styles? Styles { get; set; }
+
+    }
+}

--- a/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponse.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponse.cs
@@ -1,0 +1,13 @@
+﻿using PingPayments.Shared;
+using System.Net;
+
+namespace PingPayments.KYC.Merchant.V1.AIS.Response
+{
+    public record AisMerchantResponse : ApiResponseBase<AisMerchantResponseBody>
+    {
+        public AisMerchantResponse(HttpStatusCode StatusCode, bool IsSuccessful, ResponseBody<AisMerchantResponseBody> body, string rawBody) : base(StatusCode, IsSuccessful, body, rawBody) { }
+        public static AisMerchantResponse Successful(HttpStatusCode statusCode, AisMerchantResponseBody body, string rawBody) => new(statusCode, true, body, rawBody);
+        public static AisMerchantResponse Failure(HttpStatusCode statusCode, ErrorResponseBody error, string rawBody) => new(statusCode, false, error, rawBody);
+
+    }
+}

--- a/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponseBody.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponseBody.cs
@@ -1,0 +1,14 @@
+﻿using PingPayments.Shared;
+using System.Text.Json.Serialization;
+
+namespace PingPayments.KYC.Merchant.V1.AIS.Response
+{
+    public record AisMerchantResponseBody : EmptySuccessfulResponseBody
+    {
+        [JsonPropertyName("ais_url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("verification_id")]
+        public string VerificationId { get; set; }
+    }
+}

--- a/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponseBody.cs
+++ b/PingPayments.KYC/Merchant/V1/AIS/Response/AisMerchantResponseBody.cs
@@ -1,4 +1,5 @@
 ﻿using PingPayments.Shared;
+using System;
 using System.Text.Json.Serialization;
 
 namespace PingPayments.KYC.Merchant.V1.AIS.Response
@@ -6,7 +7,7 @@ namespace PingPayments.KYC.Merchant.V1.AIS.Response
     public record AisMerchantResponseBody : EmptySuccessfulResponseBody
     {
         [JsonPropertyName("ais_url")]
-        public string Url { get; set; }
+        public Uri Url { get; set; }
 
         [JsonPropertyName("verification_id")]
         public string VerificationId { get; set; }

--- a/PingPayments.KYC/PingKycApiClient.cs
+++ b/PingPayments.KYC/PingKycApiClient.cs
@@ -1,4 +1,5 @@
 ﻿using PingPayments.KYC.Merchant;
+using PingPayments.KYC.Merchant.V1.AIS;
 using PingPayments.KYC.Merchant.V1.Get;
 using PingPayments.KYC.Merchant.V1.Verification;
 using PingPayments.KYC.Session;
@@ -19,7 +20,8 @@ namespace PingPayments.KYC
             var merchantV1 = new MerchantV1
                 (
                     new Lazy<KycVerificationOperation>(() => new KycVerificationOperation(httpClient)),
-                    new Lazy<GetKycOperation>(() => new GetKycOperation(httpClient))
+                    new Lazy<GetKycOperation>(() => new GetKycOperation(httpClient)),
+                    new Lazy<AisKycMerchantOperation>(() => new AisKycMerchantOperation(httpClient))
                 );
             _merchant = new Lazy<IMerchantResource>(() => new MerchantResource(merchantV1));
         }

--- a/PingPayments.KYC/Shared/BankAccount.cs
+++ b/PingPayments.KYC/Shared/BankAccount.cs
@@ -23,7 +23,7 @@ namespace PingPayments.KYC.Shared
         public string Bban { get; set; }
 
         /// <summary>
-        /// Clearing numberr
+        /// Clearing number
         /// </summary>
         [JsonPropertyName("clearing")]
         public string Clearing { get; set; }

--- a/PingPayments.KYC/Shared/Distribution.cs
+++ b/PingPayments.KYC/Shared/Distribution.cs
@@ -1,0 +1,19 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PingPayments.KYC.Shared
+{
+    public record Distribution
+    {
+        /// <summary>
+        /// ISO 9362 Business Identifier Code
+        /// </summary>
+        [JsonPropertyName("email_options")]
+        public EmailOptions EmailOptions { get; set; }
+
+        /// <summary>
+        /// Bank account number (IBAN)
+        /// </summary>
+        [JsonPropertyName("sms_options")]
+        public SmsOptions SmsOptions { get; set; }
+    }
+}

--- a/PingPayments.KYC/Shared/Distribution.cs
+++ b/PingPayments.KYC/Shared/Distribution.cs
@@ -5,13 +5,13 @@ namespace PingPayments.KYC.Shared
     public record Distribution
     {
         /// <summary>
-        /// ISO 9362 Business Identifier Code
+        /// Options for email distribution
         /// </summary>
         [JsonPropertyName("email_options")]
         public EmailOptions EmailOptions { get; set; }
 
         /// <summary>
-        /// Bank account number (IBAN)
+        /// Options for sms distribution
         /// </summary>
         [JsonPropertyName("sms_options")]
         public SmsOptions SmsOptions { get; set; }

--- a/PingPayments.KYC/Shared/EmailOptions.cs
+++ b/PingPayments.KYC/Shared/EmailOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PingPayments.KYC.Shared
+{
+    public record EmailOptions
+    {
+        /// <summary>
+        /// Distribute email or not
+        /// </summary>
+        [JsonPropertyName("distribute")]
+        public bool Distribute { get; set; }
+
+        /// <summary>
+        /// Originator of the email
+        /// </summary>
+        [JsonPropertyName("originator")]
+        public string Originator { get; set; }
+
+    }
+}

--- a/PingPayments.KYC/Shared/SmsOptions.cs
+++ b/PingPayments.KYC/Shared/SmsOptions.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PingPayments.KYC.Shared
+{
+    public record SmsOptions
+    {
+        /// <summary>
+        /// Distribute sms or not
+        /// </summary>
+        [JsonPropertyName("distribute")]
+        public bool Distribute { get; set; }
+
+        /// <summary>
+        /// Message to be sent. Url will replace $url in the message
+        /// </summary>
+        [JsonPropertyName("message")]
+        public string Message { get; set; }
+
+        /// <summary>
+        /// Originator of the sms
+        /// </summary>
+        [JsonPropertyName("originator")]
+        public string Originator { get; set; }
+
+    }
+}


### PR DESCRIPTION
Distribute(object) innehåller SmsOptions(object) och EmailOptions(object). Jag funderade på att göra hjälpmetoder: Distribute.SmsOptions(), Distrubute.EmailOptions() och Distrubute.EmailAndSmsOptions() men tänker att det kanske är "onödigt" eftersom att det inte är required och därmed inte en viktig/central del av requestkroppen.
![image](https://user-images.githubusercontent.com/45557100/201068832-e0ea0d2c-8b9f-4db8-84c3-e4dc304ab904.png)
![image](https://user-images.githubusercontent.com/45557100/201069013-9ef847a9-914c-4887-b385-b2deedf9c5ad.png)
![image](https://user-images.githubusercontent.com/45557100/201069170-430b8f43-1fe2-4ed7-a904-0b944c1725f0.png)
